### PR TITLE
set postUpdateOptions: yarnDedupeHighest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "postUpdateOptions": "yarnDedupeHighest"
 }


### PR DESCRIPTION
Enable `postUpdateOptions: yarnDedupeHighest` so Renovate will dedupe after package updates.